### PR TITLE
Ignore specific tables with parameter or only dump some tables

### DIFF
--- a/src/Console/Commands/MysqlDump.php
+++ b/src/Console/Commands/MysqlDump.php
@@ -149,7 +149,7 @@ class MysqlDump extends Command
             $this->isCompressionEnabled = config('backup.mysql.compress', false);
         }
 
-        if ($ignoreTables){
+        if ($ignoreTables) {
             $this->ignoredTables = explode(',', trim($ignoreTables));
         }
 
@@ -232,7 +232,7 @@ class MysqlDump extends Command
     private function getIgnoredTablesCommandLine($database, $tables)
     {
         $command_line = '';
-        foreach ($tables as $table){
+        foreach ($tables as $table) {
             $command_line .= ' --ignore-table='.escapeshellarg($database.'.'.$table);
         }
         return $command_line;

--- a/src/Console/Commands/MysqlDump.php
+++ b/src/Console/Commands/MysqlDump.php
@@ -139,7 +139,7 @@ class MysqlDump extends Command
     {
         $compress = $this->option('compress');
         $noCompress = $this->option('no-compress');
-        $ignoreTables = $this->option("ignore-tables");
+        $ignoreTables = $this->option('ignore-tables');
 
         if ($compress) {
             $this->isCompressionEnabled = true;
@@ -150,7 +150,7 @@ class MysqlDump extends Command
         }
 
         if($ignoreTables){
-            $this->ignoredTables = explode(",", trim($ignoreTables));
+            $this->ignoredTables = explode(',', trim($ignoreTables));
         }
 
         $this->setFilename();
@@ -230,9 +230,9 @@ class MysqlDump extends Command
         }
     }
     private function getIgnoredTablesCommandLine($database, $tables){
-        $command_line = "";
+        $command_line = '';
         foreach($tables as $table){
-            $command_line .= ' --ignore-table='.escapeshellarg($database.".".$table);
+            $command_line .= ' --ignore-table='.escapeshellarg($database.'.'.$table);
         }
         return $command_line;
     }

--- a/src/Console/Commands/MysqlDump.php
+++ b/src/Console/Commands/MysqlDump.php
@@ -229,12 +229,14 @@ class MysqlDump extends Command
             $this->error("Database '{$database}' cannot be dumped");
         }
     }
+
     private function getIgnoredTablesCommandLine($database, $tables)
     {
         $command_line = '';
         foreach ($tables as $table) {
             $command_line .= ' --ignore-table='.escapeshellarg($database.'.'.$table);
         }
+        
         return $command_line;
     }
 }

--- a/src/Console/Commands/MysqlDump.php
+++ b/src/Console/Commands/MysqlDump.php
@@ -149,7 +149,7 @@ class MysqlDump extends Command
             $this->isCompressionEnabled = config('backup.mysql.compress', false);
         }
 
-        if($ignoreTables){
+        if ($ignoreTables){
             $this->ignoredTables = explode(',', trim($ignoreTables));
         }
 
@@ -229,9 +229,10 @@ class MysqlDump extends Command
             $this->error("Database '{$database}' cannot be dumped");
         }
     }
-    private function getIgnoredTablesCommandLine($database, $tables){
+    private function getIgnoredTablesCommandLine($database, $tables)
+    {
         $command_line = '';
-        foreach($tables as $table){
+        foreach ($tables as $table){
             $command_line .= ' --ignore-table='.escapeshellarg($database.'.'.$table);
         }
         return $command_line;


### PR DESCRIPTION
Hello,
thank you for the package, it is very useful! But I needed to ignore a specific table,in fact, the one that manages the backups.
So I decided to improve the package and here it is.

The use is simple, just add the parameter --ignore-tables and type inside the tables (sepparated with commas) that you want to ignore, example:
`php artisan backup:mysql-dump my_backup --ignore-tables='backups,clients'`

EDIT: I also added the "only these specific tables" feature. It is used with the argument --tables which will override the --ignore-tables argument.
`php artisan backup:mysql-dump my_backup --tables='backups,clients'`


Thank you again!